### PR TITLE
fill color

### DIFF
--- a/lib/cdn.js
+++ b/lib/cdn.js
@@ -2,7 +2,7 @@
 let canvas, ctx;
 let currentAngle = 90;
 let currentX, currentY;
-
+let col
 function createCanvas(width, height) {
   // Create a canvas element
   canvas = document.createElement("canvas");
@@ -101,19 +101,15 @@ function drawRectangle(width, height) {
 
     ctx.beginPath();
     ctx.moveTo(currentX, currentY);
-    for (let i = 0; i < 4; i++) {
-        if (i % 2 == 0) {
-            drawLine(height);
-            right(90);
-        }
-        else {
-            drawLine(width);
-            right(90);
-        }
-
-    }
+    ctx.rect(currentX, currentY, width, height)
     right(90)
     ctx.stroke();
+    if(col){
+      ctx.fillStyle = col
+      ctx.fill()
+      col = undefined
+    }
+
 }
 
 function goTo(newX, newY) {
@@ -166,6 +162,11 @@ function drawEllipse(width, height) {
       2 * Math.PI
     );
     ctx.stroke();
+    if(col){
+      ctx.fillStyle = col
+      ctx.fill()
+      col = undefined
+    }
   } else {
     console.error("Could not retrieve 2D context from canvas.");
   }
@@ -220,6 +221,7 @@ function random(min, max) {
 
 
 function drawPolygon(sideCount, length) {
+  ctx.beginPath();
   right(360 / sideCount + 180);
   if (length > 0 && typeof length == "number") {
     for (let i = 0; i < sideCount; i++) {
@@ -301,8 +303,6 @@ function showGrid(cellSize) {
 }
 
 
-
-
 function relMouseCoords(event) {
   var totalOffsetX = 0;
   var totalOffsetY = 0;
@@ -338,7 +338,7 @@ function drawStar(points, size) {
     const y1 = currentY + size
     const currentAngleInRadians = (currentAngle-90) * (Math.PI / 180);
     const initialAngle = -Math.PI / 2 + currentAngleInRadians;
-
+    ctx.beginPath();
     for (let i = 0; i < 2 * points + 1; i++) {
         const angle = initialAngle + i * angleStep;
         const r = i % 2 === 0 ? outerRadius : innerRadius;
@@ -352,6 +352,12 @@ function drawStar(points, size) {
     }
     ctx.closePath();
     ctx.stroke();
+    if(col){
+      ctx.fillStyle = col
+      ctx.fill()
+      col = undefined
+    }
+ 
 }
 
 function width(w) {
@@ -399,19 +405,17 @@ function fillColor(...clr) {
     cl[2] <= 255 &&
     cl[2] >= 0
   ) {
-    ctx.fillStyle = `rgb(${cl})`;
-    ctx.fill();
+    col = `rgb(${cl})`
   } else if (typeof clr[0] == "string" && hexRegex.test(clr[0])) {
-    ctx.fillStyle = clr[0];
-    ctx.fill();
+    col =clr[0]
   } else if (clr.length == 1 && typeof clr[0] == "string") {
-    ctx.fillStyle = clr[0];
-    ctx.fill();
+    col = clr[0]
   } else {
     console.error("Invalid color format.");
   }
   ctx.restore();
 }
+
 function text(str, fontSize = 36, fontFamily = "Arial") {
   ctx.font = `${fontSize}px ${fontFamily}`;
   ctx.textBaseline = "top";

--- a/script.js
+++ b/script.js
@@ -1,47 +1,44 @@
 createCanvas(800, 600); // Create a canvas
 // // Example usage
-// goTo(200,550);
-// drawLine(200);
-// right(90);
-// left(30);
-// drawLine(50);   
-// drawEllipse(120,80);
-// // erase();
-
-
-// right(90)
-// goTo(200,150)
-// drawPolygon(5,100)
-// showGrid(40)
-// goTo(250,350)
-// drawLine(50);
-
-// drawLine(50);
-
-// rotate(30);
-// drawLine(50);
-// drawPolygon(7, 100);
-
-// createCanvas(800, 600); // Create a canvas of size
-// drawLine(200); // Draw a line of length 100
-// goTo(700, 500);
-// left("Dfdffd")
-// drawLine(50);
-// drawStar(5, 50);
-// goTo(200, 200);
-// drawStar(5, 30);
-
-
-
 
 goTo(700,500)
-drawEllipse(120,80);
 fillColor("red") 
+drawEllipse(120,80);
 
-// animate(()=> {
-//   drawLine(100)
-  drawRectangle(100,100)
-// },1000)
+goTo(100, 100)
+fillColor(120,19,149) 
+drawEllipse(120,80);
 
+goTo(200, 200)
+//fillColor([120,60,60]) 
+drawEllipse(120,90)
 
+goTo(300,300)
+fillColor("#aa454512")
+drawEllipse(120,120)
+
+goTo(400, 400)
+drawEllipse(100,100)
+
+goTo(400,100)
+fillColor("blue")
+drawRectangle(5,50)
+
+goTo(200,100)
+drawRectangle(100,5)
+
+goTo(600,200)
+fillColor("yellow")
+drawRectangle(200,200)
+
+goTo(150,150)
+fillColor("brown")
+drawStar(5,100)
+
+goTo(180,180)
+drawStar(5,100)
 showGrid(50)
+
+goTo(280,280)
+fillColor("green")
+drawStar(5,100)


### PR DESCRIPTION
The fillColor function already works with drawStar, drawEllipse, and drawRectangle functions. Now, we need to modify all functions that use drawLine. Each draw function should begin with ctx.beginPath(); and end with ctx.closePath().
Additionally, we should incorporate this 
if(col){
      ctx.fillStyle = col
      ctx.fill()
      col = undefined
    }