### PR TITLE
Prevent drawing lines outside canvas

### DIFF
--- a/lib/cdn.js
+++ b/lib/cdn.js
@@ -2,7 +2,7 @@
 let canvas, ctx;
 let currentAngle = 90;
 let currentX, currentY;
-let col
+let col;
 function createCanvas(width, height) {
   // Create a canvas element
   canvas = document.createElement("canvas");
@@ -54,13 +54,24 @@ function drawLine(length) {
   const newX = currentX + length * Math.cos(radianAngle);
   const newY = currentY - length * Math.sin(radianAngle); // Note the negative sign for the Y-axis
 
+  let outOfBounds = false;
+  if (newX < 0 || newX > canvas.width || newY < 0 || newY > canvas.height) {
+    outOfBounds = true;
+  }
+
+  if (outOfBounds) {
+    console.warn("Warning: The line passed the margin of the canvas.");
+  }
+
+  const boundedX = Math.max(0, Math.min(newX, canvas.width));
+  const boundedY = Math.max(0, Math.min(newY, canvas.height));
+
   ctx.moveTo(currentX, currentY);
   ctx.lineTo(newX, newY);
   ctx.stroke();
 
-  currentX = newX;
-  currentY = newY;
-
+  currentX = boundedX;
+  currentY = boundedY;
 }
 
 function left(angle) {
@@ -101,15 +112,14 @@ function drawRectangle(width, height) {
 
   ctx.beginPath();
   ctx.moveTo(currentX, currentY);
-  ctx.rect(currentX, currentY, width, height)
-  right(90)
+  ctx.rect(currentX, currentY, width, height);
+  right(90);
   ctx.stroke();
   if (col) {
-    ctx.fillStyle = col
-    ctx.fill()
-    col = undefined
+    ctx.fillStyle = col;
+    ctx.fill();
+    col = undefined;
   }
-
 }
 
 function goTo(newX, newY) {
@@ -149,7 +159,6 @@ function drawEllipse(width, height) {
   const ellipseCenterX = currentX + (width * Math.cos(radianAngle)) / 2;
   const ellipseCenterY = currentY - (height * Math.sin(radianAngle)) / 2;
 
-
   // If the 2D context was retrieved successfully, draw the ellipse using bezier curves
   if (ctx) {
     const kappa = 0.5522848,
@@ -162,10 +171,38 @@ function drawEllipse(width, height) {
 
     ctx.beginPath();
     ctx.moveTo(x, ellipseCenterY);
-    ctx.bezierCurveTo(x, ellipseCenterY - oy, ellipseCenterX - ox, y, ellipseCenterX, y);
-    ctx.bezierCurveTo(ellipseCenterX + ox, y, xe, ellipseCenterY - oy, xe, ellipseCenterY);
-    ctx.bezierCurveTo(xe, ellipseCenterY + oy, ellipseCenterX + ox, ye, ellipseCenterX, ye);
-    ctx.bezierCurveTo(ellipseCenterX - ox, ye, x, ellipseCenterY + oy, x, ellipseCenterY);
+    ctx.bezierCurveTo(
+      x,
+      ellipseCenterY - oy,
+      ellipseCenterX - ox,
+      y,
+      ellipseCenterX,
+      y
+    );
+    ctx.bezierCurveTo(
+      ellipseCenterX + ox,
+      y,
+      xe,
+      ellipseCenterY - oy,
+      xe,
+      ellipseCenterY
+    );
+    ctx.bezierCurveTo(
+      xe,
+      ellipseCenterY + oy,
+      ellipseCenterX + ox,
+      ye,
+      ellipseCenterX,
+      ye
+    );
+    ctx.bezierCurveTo(
+      ellipseCenterX - ox,
+      ye,
+      x,
+      ellipseCenterY + oy,
+      x,
+      ellipseCenterY
+    );
     ctx.closePath();
     ctx.stroke();
   } else {
@@ -176,9 +213,7 @@ function drawEllipse(width, height) {
   const newY = currentY - height * Math.sin(radianAngle);
   currentX = newX;
   currentY = newY;
-};
-
-
+}
 
 function erase() {
   // Check if the 2D context (ctx) is available
@@ -194,14 +229,13 @@ function erase() {
   currentY = canvas.height / 2;
 }
 
-
 function random(min, max) {
   function isNumber(value) {
     return typeof value === "number" && !isNaN(value);
   }
 
   if (Array.isArray(min)) {
-    return min[Math.floor(Math.random() * min.length)];;
+    return min[Math.floor(Math.random() * min.length)];
   }
 
   if (min !== undefined && !isNumber(min)) {
@@ -211,7 +245,6 @@ function random(min, max) {
   if (max !== undefined && !isNumber(max)) {
     throw new TypeError("Second argument must be a number");
   }
-
 
   if (max === undefined) {
     if (min === undefined) {
@@ -223,7 +256,6 @@ function random(min, max) {
   return Math.round(Math.random() * (max - min) + min);
 }
 
-
 function drawPolygon(sideCount, length) {
   ctx.beginPath();
   right(360 / sideCount + 180);
@@ -234,7 +266,6 @@ function drawPolygon(sideCount, length) {
     }
   }
 }
-
 
 function drawTriangle(length) {
   if (length > 0 && typeof length == "number") {
@@ -276,18 +307,15 @@ function showGrid(cellSize) {
     return; // Exit the function early if validation fails
   }
 
-
   const width = canvas.width;
   const height = canvas.height;
 
   // Save the current canvas state
   ctx.save();
 
-
   // Set the stroke style for grid lines
   ctx.strokeStyle = "#ccc"; // Color of the grid lines
   ctx.lineWidth = 1; // Optional: Set line width for grid lines
-
 
   // Draw the grid lines
   ctx.beginPath();
@@ -306,12 +334,9 @@ function showGrid(cellSize) {
 
   ctx.stroke();
 
-
   ctx.restore();
   ctx.globalCompositeOperation = "source-over";
-
 }
-
 
 function relMouseCoords(event) {
   var totalOffsetX = 0;
@@ -344,8 +369,8 @@ function drawStar(points, size) {
   const innerRadius = size / 2;
   const angleStep = Math.PI / points;
 
-  const x1 = currentX
-  const y1 = currentY + size
+  const x1 = currentX;
+  const y1 = currentY + size;
   const currentAngleInRadians = (currentAngle - 90) * (Math.PI / 180);
   const initialAngle = -Math.PI / 2 + currentAngleInRadians;
   ctx.beginPath();
@@ -363,11 +388,10 @@ function drawStar(points, size) {
   ctx.closePath();
   ctx.stroke();
   if (col) {
-    ctx.fillStyle = col
-    ctx.fill()
-    col = undefined
+    ctx.fillStyle = col;
+    ctx.fill();
+    col = undefined;
   }
-
 }
 
 function width(w) {
@@ -415,11 +439,11 @@ function fillColor(...clr) {
     cl[2] <= 255 &&
     cl[2] >= 0
   ) {
-    col = `rgb(${cl})`
+    col = `rgb(${cl})`;
   } else if (typeof clr[0] == "string" && hexRegex.test(clr[0])) {
-    col = clr[0]
+    col = clr[0];
   } else if (clr.length == 1 && typeof clr[0] == "string") {
-    col = clr[0]
+    col = clr[0];
   } else {
     console.error("Invalid color format.");
   }
@@ -453,11 +477,7 @@ function move(length) {
   currentY = newY;
 }
 
-
 function animate(func, interval) {
   let id = setInterval(func, interval);
   return id; // Return the interval ID for possible later cancellation
 }
-
-
-

--- a/script.js
+++ b/script.js
@@ -1,62 +1,56 @@
 createCanvas(800, 600); // Create a canvas
 // // Example usage
 
-goTo(700,500)
-fillColor("red") 
-drawEllipse(120,80);
+goTo(700, 500);
+fillColor("red");
+drawEllipse(120, 80);
 
+goTo(100, 100);
+fillColor(120, 19, 149);
+drawEllipse(120, 80);
 
-goTo(100, 100)
-fillColor(120,19,149) 
-drawEllipse(120,80);
+goTo(100, 100);
+fillColor(120, 19, 149);
+drawEllipse(120, 80);
 
-
-goTo(100, 100)
-fillColor(120,19,149) 
-drawEllipse(120,80);
-
-
-goTo(700,500)
+goTo(700, 500);
 drawEllipse(80);
-fillColor("red") 
-erase()
-drawLine(120)
-drawEllipse(140, 100)
-drawLine(50)
+fillColor("red");
+erase();
+drawLine(120);
+drawEllipse(140, 100);
+drawLine(50);
 
+goTo(200, 200);
+//fillColor([120,60,60])
+drawEllipse(120, 90);
 
+goTo(300, 300);
+fillColor("#aa454512");
+drawEllipse(120, 120);
 
-goTo(200, 200)
-//fillColor([120,60,60]) 
-drawEllipse(120,90)
+goTo(400, 400);
+drawEllipse(100, 100);
 
-goTo(300,300)
-fillColor("#aa454512")
-drawEllipse(120,120)
+goTo(400, 100);
+fillColor("blue");
+drawRectangle(5, 50);
 
-goTo(400, 400)
-drawEllipse(100,100)
+goTo(200, 100);
+drawRectangle(100, 5);
 
-goTo(400,100)
-fillColor("blue")
-drawRectangle(5,50)
+goTo(600, 200);
+fillColor("yellow");
+drawRectangle(200, 200);
 
-goTo(200,100)
-drawRectangle(100,5)
+goTo(150, 150);
+fillColor("brown");
+drawStar(5, 100);
 
-goTo(600,200)
-fillColor("yellow")
-drawRectangle(200,200)
+goTo(180, 180);
+drawStar(5, 100);
+showGrid(50);
 
-goTo(150,150)
-fillColor("brown")
-drawStar(5,100)
-
-goTo(180,180)
-drawStar(5,100)
-showGrid(50)
-
-goTo(280,280)
-fillColor("green")
-drawStar(5,100)
-
+goTo(280, 280);
+fillColor("green");
+drawStar(5, 100);


### PR DESCRIPTION
- Added checks to ensure the new coordinates are within the canvas boundaries.
- Logged a warning if the new coordinates are out of bounds.
- Adjusted the line drawing logic to use bounded coordinates, preventing lines from going outside the canvas margins.